### PR TITLE
docs(prompt): Precise Anchoring for inline comments (use line+side; avoid position)

### DIFF
--- a/templates/request/base.njk
+++ b/templates/request/base.njk
@@ -40,7 +40,7 @@ You are conducting a comprehensive code review for PR #{{ pr.number }}. You have
 - Anchor using line + side; do not use "position".
 - Default: side="RIGHT" for added/modified lines; use "LEFT" only for deleted lines.
 - Validate anchors: only post an inline comment when you can ensure the anchor targets the intended code; otherwise post one brief general comment.
-- Suggestion blocks (```suggestion) only on side="RIGHT"; be especially careful to anchor precisely when providing suggestions.
+- Suggestion blocks (```suggestion ... ``` ) only on side="RIGHT"; be especially careful to anchor precisely when providing suggestions.
 - For multi-line ranges, set start_line/start_side and line/side consistently (same side).
 
 **IMPORTANT**: If you post any review comments, end your review summary with this exact feedback request:


### PR DESCRIPTION
Update review request template to enforce precise anchoring for inline comments

This PR introduces a "Precise Anchoring" section to the code review prompt template, guiding reviewers to anchor comments by `line` + `side` rather than the patch-relative `position` field.

Key changes:
- Instruct reviewers to anchor using `line` + `side`; avoid `position`.
- Default to `side="RIGHT"` for added/modified lines; use `side="LEFT"` only for deleted lines.
- Validate anchors before posting; if uncertain, prefer a single brief general comment over inline.
- Allow suggestion blocks (```suggestion) only on `side="RIGHT"`; emphasize precise anchoring when proposing edits.
- For multi-line ranges, set `start_line`/`start_side` and `line`/`side` consistently on the same side.

Impact:
- Reduces off-by-one and hunk-position errors when anchoring comments.
- Improves reliability of suggestion blocks and auto-applied edits.
- No runtime or functional changes; documentation/prompt-only update.

---
*🤖 This description was generated automatically. Please react with 👍 if it's helpful or 👎 if it needs improvement.*