### PR TITLE
Remove suggestion blocks from prompt

### DIFF
--- a/templates/formatting/base.njk
+++ b/templates/formatting/base.njk
@@ -14,7 +14,7 @@
 
 ### Code References:
 - Use backticks for inline code references (function names, variables, etc.)
-- In inline review comments, prefer GitHub suggestion blocks (```suggestion) for concrete code changes; ensure patches are minimal and accurate
+- In inline review comments, do NOT use GitHub suggestion blocks. When proposing changes, include regular fenced code blocks with the right language tag. Provide both "Current code:" and "Suggested improvement:" sections where helpful to show before/after clearly
 - Do not include code blocks or specific code suggestions in the top-level review summary
 - Include file paths and line numbers only within inline comments (not in the summary)
 - Use proper syntax highlighting when showing code examples

--- a/templates/guidelines/base.njk
+++ b/templates/guidelines/base.njk
@@ -15,7 +15,7 @@
 ### Comment Guidelines:
 - **HIGH CONFIDENCE ONLY**: Only suggest changes you are highly confident will improve the code
 - Post one inline comment per distinct issue and location, anchored to the exact file and line in the PR diff
-- Provide clear explanations of issues and suggest concrete improvements; when proposing code, use GitHub suggestion blocks in inline comments
+- Provide clear explanations of issues and suggest concrete improvements. When proposing code, do NOT use GitHub suggestion blocks. Instead, include regular fenced code blocks with appropriate language tags and, where useful, show “Current code:” and “Suggested improvement:” sections
 - Use a constructive, helpful tone - focus on the code, not the person
 - Include examples of better approaches when suggesting changes
 - Prioritize critical issues over minor style preferences

--- a/templates/request/base.njk
+++ b/templates/request/base.njk
@@ -28,7 +28,7 @@ You are conducting a comprehensive code review for PR #{{ pr.number }}. You have
 
 ## Action Required:
 - Use GitHub's review system to post your feedback directly on the relevant lines of code in the PR
-- For any code-specific issue, you MUST post an inline review comment anchored to the exact file and line in the PR diff; when proposing code changes, use GitHub suggestion blocks (```suggestion ... ```)
+- For any code-specific issue, post an inline review comment anchored to the exact file and line in the PR diff. When proposing code changes, do NOT use GitHub suggestion blocks. Instead, include regular fenced code blocks with appropriate language tags and use clear sections like "Current code:" and "Suggested improvement:"
 - The review summary MUST be at most 3 sentences and MUST NOT include code-specific suggestions, code blocks, or file/line references. Do not repeat details from inline comments.
 - Submit a single GitHub review containing your inline comments plus the brief summary. Do not create multiple reviews.
 - If you cannot find a valid diff anchor for a code-specific suggestion, comment on the closest changed line and clearly reference the exact location; only if no anchor is possible, write one short general comment for that item.
@@ -40,7 +40,7 @@ You are conducting a comprehensive code review for PR #{{ pr.number }}. You have
 - Anchor using line + side; do not use "position".
 - Default: side="RIGHT" for added/modified lines; use "LEFT" only for deleted lines.
 - Validate anchors: only post an inline comment when you can ensure the anchor targets the intended code; otherwise post one brief general comment.
-- Suggestion blocks (```suggestion ... ``` ) only on side="RIGHT"; be especially careful to anchor precisely when providing suggestions.
+- Do not use GitHub suggestion blocks. Provide code examples with regular fenced code blocks. Be especially careful to anchor precisely to the intended line(s).
 - For multi-line ranges, set start_line/start_side and line/side consistently (same side).
 
 **IMPORTANT**: If you post any review comments, end your review summary with this exact feedback request:


### PR DESCRIPTION
Remove GitHub suggestion blocks from review prompts and replace with fenced code blocks

This PR updates the review prompt templates to stop using GitHub suggestion blocks and instead rely on regular fenced code blocks for proposed changes. This avoids incorrect/mishandled suggestions and makes before/after examples clearer and more consistent.

Key changes:
- Update templates/formatting/base.njk: Instruct reviewers not to use GitHub suggestion blocks; when proposing changes, use fenced code blocks with the appropriate language tag, optionally showing "Current code:" and "Suggested improvement:" sections.
- Update templates/guidelines/base.njk: Clarify comment guidelines to provide concrete improvements using fenced code blocks rather than suggestion blocks.
- Update templates/request/base.njk: Adjust action requirements to anchor inline comments precisely but avoid suggestion blocks; emphasize using fenced code blocks and clear before/after sections.

Impact:
- Improves clarity and reduces agent mishandling of suggestions during reviews.
- No runtime or API changes; affects reviewer/agent guidance only.
- No migrations or config changes required.

---
*🤖 This description was generated automatically. Please react with 👍 if it's helpful or 👎 if it needs improvement.*