### PR TITLE
Reduce checkout version

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -26,7 +26,7 @@ runs:
   using: "composite"
   steps:
     - name: Checkout PR Head
-      uses: actions/checkout@1e31de5234b9f8995739874a8ce0492dc87873e2 # v4.0.0
+      uses: actions/checkout@3df4ab11eba7bda6032a0b82a6bb43b11571feac # v4.0.0
       with:
         token: ${{ inputs.github_token }}
         ref: refs/pull/${{ inputs.pull_number }}/head

--- a/action.yml
+++ b/action.yml
@@ -26,7 +26,7 @@ runs:
   using: "composite"
   steps:
     - name: Checkout PR Head
-      uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      uses: actions/checkout@1e31de5234b9f8995739874a8ce0492dc87873e2 # v4.0.0
       with:
         token: ${{ inputs.github_token }}
         ref: refs/pull/${{ inputs.pull_number }}/head


### PR DESCRIPTION
Update actions/checkout pin to v4.0.0

This PR downgrades the GitHub Actions `actions/checkout` used by our composite action to v4.0.0 (commit SHA pin) to address compatibility and policy alignment concerns.

Key changes
- Downgrade `actions/checkout` from v4.2.2 to v4.0.0, pinned by commit (`1e31de5…`) for supply‑chain safety
- Continue using a commit SHA rather than a tag to maintain immutability
- Applies only to the composite action step that checks out the PR head; no production/runtime code is affected

Context
- Tracks rationale discussed in Augment Agent issue #2: https://github.com/augmentcode/augment-agent/issues/2

Risk and impact
- Low risk: CI-only change; behavior remains functionally equivalent for checkout of PR heads
- Easy rollback: revert to prior pinned SHA (`11bd719…`, v4.2.2) if needed

---
*🤖 This description was generated automatically. Please react with 👍 if it's helpful or 👎 if it needs improvement.*