### PR TITLE
Add optional fetch_depth option for shallow clones

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,7 @@ Each example includes a complete workflow file that you can copy to your `.githu
 | `model`                | Optional model name to use; passed directly to augment agent                               | No       | e.g. `sonnet4`, from `auggie --list-models`         |
 | `rules`                | JSON array of rule file paths forwarded to augment agent as repeated `--rules` flags       | No       | `'[".augment/rules.md"]'`                           |
 | `mcp_configs`          | JSON array of MCP config file paths forwarded as repeated `--mcp-config` flags             | No       | `'[".augment/mcp.json"]'`                           |
+| `fetch_depth`          | Number of commits to fetch. Use `0` for full history (default), `1` for shallow clone, or any positive integer for specific depth | No       | `1` (shallow), `50` (last 50 commits), `0` (full) |
 
 ## How It Works
 

--- a/action.yml
+++ b/action.yml
@@ -30,6 +30,10 @@ inputs:
   mcp_configs:
     description: "Optional JSON array of MCP config file paths to forward as --mcp-config flags to augmentcode/augment-agent."
     required: false
+  fetch_depth:
+    description: "Number of commits to fetch. Use '0' for full history (default), '1' for shallow clone (latest commit only), or any positive integer for a specific depth."
+    required: false
+    default: "0"
 
 runs:
   using: "composite"
@@ -39,7 +43,7 @@ runs:
       with:
         token: ${{ inputs.github_token }}
         ref: refs/pull/${{ inputs.pull_number }}/head
-        fetch-depth: 0
+        fetch-depth: ${{ inputs.fetch_depth }}
 
     - name: Prepare Custom Context
       id: custom_context


### PR DESCRIPTION
The default `fetch-depth` of `0` can be quite slow for large repositories with long history. This should give the option of constraining fetch depth to an arbitrary number of commits to speed up checkouts.