### PR TITLE
Remove rules and mcp_configs input parameters

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,9 +80,7 @@ Each example includes a complete workflow file that you can copy to your `.githu
 | `pull_number`          | The number of the pull request being reviewed                                              | Yes      | `${{ github.event.pull_request.number }}`           |
 | `repo_name`            | The full name (owner/repo) of the repository                                               | Yes      | `${{ github.repository }}`                          |
 | `custom_guidelines`    | Custom guidelines to include in PR reviews                                                 | No       | See [Custom Guidelines](#custom-guidelines) section |
-| `model`                | Optional model name to use; passed directly to augment agent                               | No       | e.g. `sonnet4`, from `auggie --list-models`         |
-| `rules`                | JSON array of rule file paths forwarded to augment agent as repeated `--rules` flags       | No       | `'[".augment/rules.md"]'`                           |
-| `mcp_configs`          | JSON array of MCP config file paths forwarded as repeated `--mcp-config` flags             | No       | `'[".augment/mcp.json"]'`                           |
+| `model`                | Optional model name to use; passed directly to augment agent                               | No       | e.g. `sonnet4`, from `auggie --list-models` |
 
 ## How It Works
 

--- a/action.yml
+++ b/action.yml
@@ -24,12 +24,6 @@ inputs:
   model:
     description: "Optional model name to use; passed directly to augmentcode/augment-agent."
     required: false
-  rules:
-    description: "Optional JSON array of rules file paths to forward as --rules flags to augmentcode/augment-agent."
-    required: false
-  mcp_configs:
-    description: "Optional JSON array of MCP config file paths to forward as --mcp-config flags to augmentcode/augment-agent."
-    required: false
 
 runs:
   using: "composite"
@@ -65,5 +59,3 @@ runs:
         repo_name: ${{ inputs.repo_name }}
         custom_context: ${{ steps.custom_context.outputs.context }}
         model: ${{ inputs.model }}
-        rules: ${{ inputs.rules }}
-        mcp_configs: ${{ inputs.mcp_configs }}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "augment-review-pr",
-  "version": "0.1.4",
+  "version": "0.1.3",
   "description": "AI-powered code assistance for reviewing pull requests using Augment's intelligent development tools",
   "main": "action.yml",
   "type": "module",


### PR DESCRIPTION
Remove `rules` and `mcp_configs` input parameters from GitHub Action

This PR simplifies the action interface by removing two optional input parameters that are no longer supported in the underlying augment-agent:

- **Remove `rules` input**: Eliminates the ability to pass custom rule file paths to the augment agent
- **Remove `mcp_configs` input**: Eliminates the ability to pass MCP configuration file paths to the augment agent  
- **Update documentation**: Remove references to these parameters from the README inputs table
- **Align version**: Downgrade version from 0.1.4 to 0.1.3 to match the augment-agent repository

These changes align with upstream changes in [augment-agent PR #9](https://github.com/augmentcode/augment-agent/pull/9). Users who previously relied on these parameters will need to use alternative configuration methods.

---
*🤖 This description was generated automatically. Please react with 👍 if it's helpful or 👎 if it needs improvement.*