### PR TITLE
Enable reviewing PR in another repo

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -52,11 +52,13 @@ runs:
       shell: bash
       run: |
         if [ -n "$CUSTOM_GUIDELINES" ]; then
-          echo 'context<<EOF' >> $GITHUB_OUTPUT
-          echo "$(jq -n --arg guidelines "$CUSTOM_GUIDELINES" --arg repo "${{ inputs.repo_name }}" --arg pull_number "${{ inputs.pull_number }}" '{custom_guidelines: $guidelines, repo_name: $repo, pull_number: $pull_number}')" >> $GITHUB_OUTPUT
-          echo 'EOF' >> $GITHUB_OUTPUT
+          echo 'context<<EOF' >> "$GITHUB_OUTPUT"
+          jq -n --arg guidelines "$CUSTOM_GUIDELINES" --arg repo "${{ inputs.repo_name }}" --arg pull_number "${{ inputs.pull_number }}" '{custom_guidelines: $guidelines, repo_name: $repo, pull_number: $pull_number}' >> "$GITHUB_OUTPUT"
+          echo 'EOF' >> "$GITHUB_OUTPUT"
         else
-          echo "context=$(jq -n --arg repo \"${{ inputs.repo_name }}\" --arg pull_number \"${{ inputs.pull_number }}\" '{repo_name: $repo, pull_number: $pull_number}')" >> $GITHUB_OUTPUT
+          echo 'context<<EOF' >> "$GITHUB_OUTPUT"
+          jq -n --arg repo "${{ inputs.repo_name }}" --arg pull_number "${{ inputs.pull_number }}" '{repo_name: $repo, pull_number: $pull_number}' >> "$GITHUB_OUTPUT"
+          echo 'EOF' >> "$GITHUB_OUTPUT"
         fi
       env:
         CUSTOM_GUIDELINES: ${{ inputs.custom_guidelines }}

--- a/templates/guidelines/base.njk
+++ b/templates/guidelines/base.njk
@@ -11,8 +11,9 @@
 - You are currently checked out on the head ref of this pull request.
 - All changed files for the PR are in the context as CHANGED_FILES
 - The full set of changes for the PR are in the context as DIFF
-- Always target the PR's repository for GitHub operations. Do not use the workflow repository.
-- Explicitly set owner/repo for every GitHub call to: {{ custom.repo_name }}; PR number: {{ custom.pull_number }}
+{% if custom.repo_name %}
+- Explicitly set owner/repo to '{{ custom.repo_name }}' for GitHub operations
+{% endif %}
 
 ### Comment Guidelines:
 - **HIGH CONFIDENCE ONLY**: Only suggest changes you are highly confident will improve the code


### PR DESCRIPTION
### Purpose

Resolves #21 

To help drive visibility and adoption of AI tooling / workflows at our company, I recently implemented a central GHA workflow that allows folks to request an Auggie review of a PR in another repo in the org.  This uncovered a couple bugs in the `review-pr` action, where it was trying to post reviews to the workflow repo instead of the PR’s repo.

I forked the repo and made a few backwards-compatible tweaks (no new inputs, defaults unchanged) to ensure PR reviews are posted to the repo specified by `repo_name` (the PR’s repo) rather than the workflow repo.  I verified that this is working now for both same-repo and cross-repo workflows.

### Changes

- Use `repo_name` for checkout so the PR head is fetched from the target repo
- Use a separate checkout path (`pr`) to avoid clobbering local files (e.g. rules) in the workflow repo
- Ensure reviews target the PR’s repo
    - Pass `repo_name` / `pull_number` in `custom_context`
    - Update template guidance with clear instruction to use the PR’s repo / pull number for all GitHub operations